### PR TITLE
[PEx] Make search strategies subclasses thread safe, minor refactoring

### DIFF
--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
@@ -101,10 +101,10 @@ public class RuntimeExecutor {
 
     private static void process(boolean resume) throws Exception {
         try {
+            // create and add first task through scheduler 0
+            schedulers.get(0).getSearchStrategy().createFirstTask();
+
             ArrayList<TimedCall> timedCalls = new ArrayList<>();
-            
-            SearchStrategy.createFirstTask();
-            
             for (int i = 0; i < PExplicitGlobal.getMaxThreads(); i++) {
                 timedCalls.add( new TimedCall(schedulers.get(i), resume, i));
             }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
@@ -11,6 +11,9 @@ import pexplicit.runtime.scheduler.explicit.strategy.SearchStrategyMode;
  */
 @Getter
 public class PExplicitConfig {
+    @Getter
+    @Setter
+    private static int numThreads = 1;
     // default name of the test driver
     final String testDriverDefault = "DefaultImpl";
     // name of the test driver
@@ -64,9 +67,5 @@ public class PExplicitConfig {
     //max number of children search tasks
     @Setter
     int maxChildrenPerTask = 2;
-
-    @Getter
-    @Setter
-    private static int numThreads = 1;    
 
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/ForeignFunctionInterface.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/ForeignFunctionInterface.java
@@ -5,24 +5,24 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class ForeignFunctionInterface {
-  /**
-   * Invoke a foreign function with a void return type
-   *
-   * @param fn function to invoke
-   * @param args arguments
-   */
-  public static void accept(Consumer<List<Object>> fn, Object... args) {
-    fn.accept(List.of(args));
-  }
+    /**
+     * Invoke a foreign function with a void return type
+     *
+     * @param fn   function to invoke
+     * @param args arguments
+     */
+    public static void accept(Consumer<List<Object>> fn, Object... args) {
+        fn.accept(List.of(args));
+    }
 
-  /**
-   * Invoke a foreign function with a non-void return type
-   *
-   * @param fn function to invoke
-   * @param args arguments
-   * @return the return value of the function
-   */
-  public static Object apply(Function<List<Object>, Object> fn, Object... args) {
-    return fn.apply(List.of(args));
-  }
+    /**
+     * Invoke a foreign function with a non-void return type
+     *
+     * @param fn   function to invoke
+     * @param args arguments
+     * @return the return value of the function
+     */
+    public static Object apply(Function<List<Object>, Object> fn, Object... args) {
+        return fn.apply(List.of(args));
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
@@ -6,24 +6,75 @@ import pexplicit.commandline.PExplicitConfig;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.scheduler.Scheduler;
-import pexplicit.runtime.scheduler.explicit.strategy.SearchStrategyMode;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.checkerframework.checker.units.qual.A;
 /**
  * Represents global data structures represented with a singleton class
  */
 public class PExplicitGlobal {
-    
+
 
     @Getter
     private static final int maxThreads = PExplicitConfig.getNumThreads();
-
-
+    /**
+     * Mapping from machine type to list of all machine instances
+     */
+    @Getter
+    private static final Map<Integer, Map<Class<? extends PMachine>, List<PMachine>>> machineListByTypePerThread = new ConcurrentHashMap<>(); // This is per thread; so make this map of tiD to same Map
+    /**
+     * Set of machines
+     */
+    @Getter
+    private static final Map<Integer, SortedSet<PMachine>> machineSetPerThread = new ConcurrentHashMap<>();
     private static AtomicLong threadsBlocking = new AtomicLong(0);
+    //  @Getter
+    //  @Setter
+    // private static Map< >
+    @Getter
+    private static Map<Long, Integer> tID_to_localtID = new ConcurrentHashMap<>();
+    /**
+     * PModel
+     **/
+    @Getter
+    @Setter
+    private static PModel model = null;
+    /**
+     * Global configuration
+     **/
+    @Getter
+    @Setter
+    private static PExplicitConfig config = null;
+
+    /**
+     * Mapping from machine type to list of all machine instances
+     */
+    //  @Getter
+    // private static final Map<Class<? extends PMachine>, List<PMachine>> machineListByType = new HashMap<>(); // This is per thread; so make this map of tiD to same Map
+    /**
+     * Scheduler
+     **/
+    // @Getter
+    // @Setter
+    // private static Scheduler scheduler = null; // Remove this!
+
+    @Getter
+    @Setter
+    private static ArrayList<Scheduler> schedulers = new ArrayList<>();
+    /**
+     * Status of the run
+     **/
+    @Getter
+    @Setter
+    private static STATUS status = STATUS.INCOMPLETE;
+    /**
+     * Results of the run
+     **/
+    @Getter
+    @Setter
+    private static String result = null;
 
     // Method to get the current value of threadSafeLong
     public static long getThreadsBlocking() {
@@ -39,100 +90,36 @@ public class PExplicitGlobal {
         threadsBlocking.decrementAndGet();
     }
 
-    //  @Getter
-    //  @Setter
-    // private static Map< >    
-    @Getter
-    private static Map <Long, Integer> tID_to_localtID = new ConcurrentHashMap<>();
-
-
     // Method to add to tID_to_localtID
     public static void addTotIDtolocaltID(long tID, Integer localtID) {
         tID_to_localtID.put(tID, localtID);
     }
 
-    /**
-     * Mapping from machine type to list of all machine instances
-     */    
-    //  @Getter
-    // private static final Map<Class<? extends PMachine>, List<PMachine>> machineListByType = new HashMap<>(); // This is per thread; so make this map of tiD to same Map
-    /**
-     * Mapping from machine type to list of all machine instances
-     */    
-    @Getter
-    private static final Map< Integer, Map<Class<? extends PMachine>, List<PMachine>>> machineListByTypePerThread = new ConcurrentHashMap<>(); // This is per thread; so make this map of tiD to same Map
-
     public static Map<Class<? extends PMachine>, List<PMachine>> getMachineListByType() {
         int localtID = tID_to_localtID.get(Thread.currentThread().getId());
         if (!machineListByTypePerThread.containsKey(localtID)) {
             machineListByTypePerThread.put(localtID, new HashMap<>()); // Initialize with an empty HashMap if key doesn't exist
-        }        
-        return machineListByTypePerThread.get(localtID);   
+        }
+        return machineListByTypePerThread.get(localtID);
     }
 
-    public static void putMachineListByType( Map<Class<? extends PMachine>, List<PMachine>> machineListByType  ) {
+    public static void putMachineListByType(Map<Class<? extends PMachine>, List<PMachine>> machineListByType) {
         int localtID = tID_to_localtID.get(Thread.currentThread().getId());
-        machineListByTypePerThread.put(localtID, machineListByType);        
+        machineListByTypePerThread.put(localtID, machineListByType);
     }
 
-    /**
-     * Set of machines
-     */
-    @Getter
-    private static final Map< Integer, SortedSet<PMachine>> machineSetPerThread = new ConcurrentHashMap<>();
-    
-    
-    public static SortedSet<PMachine> getMachineSet () {
+    public static SortedSet<PMachine> getMachineSet() {
         int localtID = tID_to_localtID.get(Thread.currentThread().getId());
         if (!machineSetPerThread.containsKey(localtID)) {
             machineSetPerThread.put(localtID, new TreeSet<>());
         }
         return machineSetPerThread.get(localtID);
     }
-    
-    /**
-     * PModel
-     **/
-    @Getter
-    @Setter
-    private static PModel model = null;
-    /**
-     * Global configuration
-     **/
-    @Getter
-    @Setter
-    private static PExplicitConfig config = null;
-    /**
-     * Scheduler
-     **/
-    // @Getter
-    // @Setter
-    // private static Scheduler scheduler = null; // Remove this!
-
-    @Getter
-    @Setter
-    private static ArrayList<Scheduler> schedulers = new ArrayList<>();    
-
 
     public static Scheduler getScheduler() {
         int localtID = tID_to_localtID.get(Thread.currentThread().getId());
-        return schedulers.get(localtID);        
+        return schedulers.get(localtID);
     }
-
-
-    /**
-     * Status of the run
-     **/
-    @Getter
-    @Setter
-    private static STATUS status = STATUS.INCOMPLETE;    
-    
-    /**
-     * Results of the run
-     **/
-    @Getter
-    @Setter    
-    private static String result = null;
 
     /**
      * Get a machine of a given type and index if exists, else return null.
@@ -163,7 +150,7 @@ public class PExplicitGlobal {
     public static void addGlobalMachine(PMachine machine, int machineCount) {
         Map<Class<? extends PMachine>, List<PMachine>> machineListByType = getMachineListByType();
         if (!machineListByType.containsKey(machine.getClass())) {
-            machineListByType.put(machine.getClass(), new ArrayList<>()); 
+            machineListByType.put(machine.getClass(), new ArrayList<>());
             putMachineListByType(machineListByType); // PIN: Need lock and key somewhere here! Also, is this local copy ok for future use in this function? Need lock and key for future use?
         }
         assert (machineCount == machineListByType.get(machine.getClass()).size());

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
@@ -150,7 +150,7 @@ public class PExplicitGlobal {
             return null;
         }
         PMachine result = machineListByType.get(pid.getType()).get(pid.getTypeId());
-        assert (machineSet.contains(result));
+        assert (getMachineSet().contains(result));
         return result;
     }
 
@@ -168,7 +168,7 @@ public class PExplicitGlobal {
         }
         assert (machineCount == machineListByType.get(machine.getClass()).size());
         machineListByType.get(machine.getClass()).add(machine);
-        machineSet.add(machine);
+        getMachineSet().add(machine);
         assert (machineListByType.get(machine.getClass()).get(machineCount) == machine);
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -13,8 +13,6 @@ import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.machine.PMonitor;
 import pexplicit.runtime.machine.State;
 import pexplicit.runtime.machine.events.PContinuation;
-import pexplicit.runtime.scheduler.choice.Choice;
-import pexplicit.runtime.scheduler.choice.ScheduleChoice;
 import pexplicit.runtime.scheduler.choice.ScheduleSearchUnit;
 import pexplicit.runtime.scheduler.choice.SearchUnit;
 import pexplicit.runtime.scheduler.explicit.ExplicitSearchScheduler;
@@ -209,9 +207,9 @@ public class PExplicitLogger {
     /**
      * Log when backtracking to a search unit
      *
-     * @param stepNum Step number
+     * @param stepNum   Step number
      * @param choiceNum Choice number
-     * @param unit Search unit to which backtracking to
+     * @param unit      Search unit to which backtracking to
      */
     public static void logBacktrack(int stepNum, int choiceNum, SearchUnit unit) {
         if (verbosity > 1) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -315,7 +315,7 @@ public class PExplicitLogger {
      * @param creator Machine that created this machine
      */
     public static void logCreateMachine(PMachine machine, PMachine creator) {
-        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());        
+        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
         ((PExplicitGlobal.getSchedulers()).get(localtID)).updateLogNumber();
         if (typedLogEnabled()) {
             typedLog(LogType.CreateLog, String.format("%s was created by %s.", machine, creator));
@@ -323,7 +323,7 @@ public class PExplicitLogger {
     }
 
     public static void logSendEvent(PMachine sender, PMessage message) {
-        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId()); 
+        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
         ((PExplicitGlobal.getSchedulers()).get(localtID)).updateLogNumber();
         if (typedLogEnabled()) {
             String payloadMsg = "";
@@ -341,7 +341,7 @@ public class PExplicitLogger {
      * @param machine Machine that is entering the state
      */
     public static void logStateEntry(PMachine machine) {
-        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId()); 
+        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
         ((PExplicitGlobal.getSchedulers()).get(localtID)).updateLogNumber();
         if (typedLogEnabled()) {
             typedLog(LogType.StateLog, String.format("%s enters state %s.", machine, machine.getCurrentState()));
@@ -354,7 +354,7 @@ public class PExplicitLogger {
      * @param machine Machine that is exiting the state
      */
     public static void logStateExit(PMachine machine) {
-        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId()); 
+        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
         ((PExplicitGlobal.getSchedulers()).get(localtID)).updateLogNumber();
         if (typedLogEnabled()) {
             typedLog(LogType.StateLog, String.format("%s exits state %s.", machine, machine.getCurrentState()));
@@ -362,7 +362,7 @@ public class PExplicitLogger {
     }
 
     public static void logRaiseEvent(PMachine machine, PEvent event) {
-        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId()); 
+        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
         ((PExplicitGlobal.getSchedulers()).get(localtID)).updateLogNumber();
         if (typedLogEnabled()) {
             typedLog(LogType.RaiseLog, String.format("%s raised event %s in state %s.", machine, event, machine.getCurrentState()));
@@ -370,7 +370,7 @@ public class PExplicitLogger {
     }
 
     public static void logStateTransition(PMachine machine, State newState) {
-        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId()); 
+        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
         ((PExplicitGlobal.getSchedulers()).get(localtID)).updateLogNumber();
         if (typedLogEnabled()) {
             typedLog(LogType.GotoLog, String.format("%s is transitioning from state %s to state %s.", machine, machine.getCurrentState(), newState));
@@ -378,7 +378,7 @@ public class PExplicitLogger {
     }
 
     public static void logReceive(PMachine machine, PContinuation continuation) {
-        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId()); 
+        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
         ((PExplicitGlobal.getSchedulers()).get(localtID)).updateLogNumber();
         if (typedLogEnabled()) {
             typedLog(LogType.ReceiveLog, String.format("%s is waiting to dequeue an event of type %s or %s in state %s.",
@@ -387,7 +387,7 @@ public class PExplicitLogger {
     }
 
     public static void logMonitorProcessEvent(PMonitor monitor, PMessage message) {
-        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId()); 
+        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
         ((PExplicitGlobal.getSchedulers()).get(localtID)).updateLogNumber();
         if (typedLogEnabled()) {
             typedLog(LogType.MonitorLog, String.format("%s is processing event %s in state %s.",
@@ -396,7 +396,7 @@ public class PExplicitLogger {
     }
 
     public static void logDequeueEvent(PMachine machine, PMessage message) {
-        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId()); 
+        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
         ((PExplicitGlobal.getSchedulers()).get(localtID)).updateLogNumber();
         if (typedLogEnabled()) {
             String payloadMsg = "";

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
@@ -249,8 +249,8 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
      */
     public PMachineValue create(
             Class<? extends PMachine> machineType, PValue<?> payload, Function<Integer, ? extends PMachine> constructor) {
-                int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
-                PMachine machine = ((PExplicitGlobal.getSchedulers()).get(localtID)).allocateMachine(machineType, constructor);
+        int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
+        PMachine machine = ((PExplicitGlobal.getSchedulers()).get(localtID)).allocateMachine(machineType, constructor);
         PMessage msg = new PMessage(PEvent.createMachine, machine, payload);
         sendBuffer.add(msg);
         return new PMachineValue(machine);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
@@ -248,7 +248,7 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
      * @return New machine as a PMachineValue
      */
     public PMachineValue create(
-            Class<? extends PMachine> machineType, PValue<?> payload, Function<Integer, ? extends PMachine> constructor) {        
+            Class<? extends PMachine> machineType, PValue<?> payload, Function<Integer, ? extends PMachine> constructor) {
                 int localtID = (PExplicitGlobal.getTID_to_localtID()).get(Thread.currentThread().getId());
                 PMachine machine = ((PExplicitGlobal.getSchedulers()).get(localtID)).allocateMachine(machineType, constructor);
         PMessage msg = new PMessage(PEvent.createMachine, machine, payload);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/MessageQueue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/MessageQueue.java
@@ -3,7 +3,6 @@ package pexplicit.runtime.machine.buffer;
 import lombok.Getter;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.utils.exceptions.PExplicitRuntimeException;
-import pexplicit.utils.misc.Assert;
 import pexplicit.values.PMessage;
 
 import java.io.Serializable;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
@@ -62,9 +62,9 @@ public class Schedule implements Serializable {
     /**
      * Set the schedule choice at a choice depth.
      *
-     * @param stepNum    Step number
-     * @param choiceNum  Choice number
-     * @param current    Machine to set as current schedule choice
+     * @param stepNum   Step number
+     * @param choiceNum Choice number
+     * @param current   Machine to set as current schedule choice
      */
     public void setScheduleChoice(int stepNum, int choiceNum, PMachineId current) {
         if (choiceNum == choices.size()) {
@@ -83,9 +83,9 @@ public class Schedule implements Serializable {
     /**
      * Set the data choice at a choice depth.
      *
-     * @param stepNum    Step number
-     * @param choiceNum  Choice number
-     * @param current    PValue to set as current schedule choice
+     * @param stepNum   Step number
+     * @param choiceNum Choice number
+     * @param current   PValue to set as current schedule choice
      */
     public void setDataChoice(int stepNum, int choiceNum, PValue<?> current) {
         if (choiceNum == choices.size()) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
@@ -83,7 +83,7 @@ public abstract class Scheduler implements SchedulerInterface {
      */
     public abstract void run() throws TimeoutException, InterruptedException;
 
-    
+
     /**
      * Run the scheduler.
      *

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/DataSearchUnit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/DataSearchUnit.java
@@ -5,7 +5,7 @@ import pexplicit.values.PValue;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DataSearchUnit extends SearchUnit<PValue<?>>{
+public class DataSearchUnit extends SearchUnit<PValue<?>> {
     /**
      * Constructor
      */

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleSearchUnit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleSearchUnit.java
@@ -1,7 +1,6 @@
 package pexplicit.runtime.scheduler.choice;
 
 import pexplicit.runtime.machine.PMachineId;
-import pexplicit.runtime.scheduler.explicit.StepState;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -1,12 +1,9 @@
 package pexplicit.runtime.scheduler.explicit;
 
 import com.google.common.hash.Hashing;
-
 import lombok.Getter;
 import lombok.Setter;
-
 import org.apache.commons.lang3.StringUtils;
-
 import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.STATUS;
 import pexplicit.runtime.logger.PExplicitLogger;
@@ -15,7 +12,6 @@ import pexplicit.runtime.logger.StatWriter;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.scheduler.Scheduler;
-import pexplicit.runtime.scheduler.choice.Choice;
 import pexplicit.runtime.scheduler.choice.ScheduleChoice;
 import pexplicit.runtime.scheduler.choice.SearchUnit;
 import pexplicit.runtime.scheduler.explicit.strategy.*;
@@ -28,20 +24,23 @@ import pexplicit.values.PValue;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.Collections;
-import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Represents the scheduler for performing explicit-state model checking
  */
 public class ExplicitSearchScheduler extends Scheduler {
-    
+
     /**
      * Map from state hash to iteration when first visited
      */
-    private static final transient Map<Object, Integer> stateCache = new ConcurrentHashMap<>();  
+    private static final transient Map<Object, Integer> stateCache = new ConcurrentHashMap<>();
 
     /**
      * Search strategy orchestrator
@@ -93,8 +92,7 @@ public class ExplicitSearchScheduler extends Scheduler {
     public void run() throws TimeoutException {
 
 
-    }    
-
+    }
 
 
     /**
@@ -104,10 +102,9 @@ public class ExplicitSearchScheduler extends Scheduler {
      */
     @Override
     public void runParallel() throws TimeoutException, InterruptedException {
-        
+
         // PExplicitLogger.logRunTest();  // TODO : Add log Info feature
-        
-       
+
 
         // PExplicitGlobal.setResult("incomplete"); // TODO: Set Result object
 
@@ -115,20 +112,20 @@ public class ExplicitSearchScheduler extends Scheduler {
         // if (PExplicitGlobal.getConfig().getVerbosity() == 0) {  // TODO : Add log Info feature
         //     printProgressHeader(true);
         // }
-        
+
 
         while (true) {
             // schedule limit not reached and there are pending tasks
             // set the next task
             SearchTask nextTask = setNextTask();
-            if (nextTask == null ) {  // || PIN: PExplicitGlobal.getStatus() == STATUS.SCHEDULEOUT
+            if (nextTask == null) {  // || PIN: PExplicitGlobal.getStatus() == STATUS.SCHEDULEOUT
                 // all tasks completed or schedule limit reached
                 break;
-            }            
+            }
             // PExplicitLogger.logStartTask(searchStrategy.getCurrTask());   // TODO : Add log Info feature
             isDoneIterating = false;
             while (!isDoneIterating) {
-                 searchStrategy.incrementIteration();
+                searchStrategy.incrementIteration();
                 // TODO : Add log Info feature
                 // PExplicitLogger.logStartIteration(searchStrategy.getCurrTask(), SearchStatistics.iteration, stepNumber); // TODO : Add log Info feature
                 if (stepNumber == 0) {
@@ -140,9 +137,6 @@ public class ExplicitSearchScheduler extends Scheduler {
             addRemainingChoicesAsChildrenTasks();
             endCurrTask();
             // PExplicitLogger.logEndTask(searchStrategy.getCurrTask(), searchStrategy.getNumSchedulesInCurrTask()); // TODO : Add log Info feature
-
-
-
 
 
         }
@@ -451,7 +445,7 @@ public class ExplicitSearchScheduler extends Scheduler {
     private void addRemainingChoicesAsChildrenTasks() throws InterruptedException {
         SearchTask parentTask = searchStrategy.getCurrTask();
         int numChildrenAdded = 0;
-        for (int i: parentTask.getSearchUnitKeys(false)) {
+        for (int i : parentTask.getSearchUnitKeys(false)) {
             SearchUnit unit = parentTask.getSearchUnit(i);
             // if search unit at this depth is non-empty
             if (!unit.getUnexplored().isEmpty()) {
@@ -482,7 +476,7 @@ public class ExplicitSearchScheduler extends Scheduler {
         newTask.addSuffixSearchUnit(choiceNum, unit);
 
         if (!isExact) {
-            for (int i: parentTask.getSearchUnitKeys(false)) {
+            for (int i : parentTask.getSearchUnitKeys(false)) {
                 if (i > choiceNum) {
                     if (i > maxChoiceNum) {
                         maxChoiceNum = i;
@@ -538,7 +532,7 @@ public class ExplicitSearchScheduler extends Scheduler {
 
     private void postIterationCleanup() {
         SearchTask task = searchStrategy.getCurrTask();
-        for (int cIdx: task.getSearchUnitKeys(true)) {
+        for (int cIdx : task.getSearchUnitKeys(true)) {
             SearchUnit unit = task.getSearchUnit(cIdx);
             if (unit.getUnexplored().isEmpty()) {
                 task.clearSearchUnit(cIdx);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -47,7 +47,6 @@ public class ExplicitSearchScheduler extends Scheduler {
      * Search strategy orchestrator
      */
     @Getter
-    @Setter
     private final transient SearchStrategy searchStrategy;
     /**
      * Backtrack choice number
@@ -104,7 +103,7 @@ public class ExplicitSearchScheduler extends Scheduler {
      * @throws TimeoutException Throws timeout exception if timeout is reached
      */
     @Override
-    public void runParallel() throws TimeoutException {
+    public void runParallel() throws TimeoutException, InterruptedException {
         
         // PExplicitLogger.logRunTest();  // TODO : Add log Info feature
         
@@ -129,7 +128,8 @@ public class ExplicitSearchScheduler extends Scheduler {
             // PExplicitLogger.logStartTask(searchStrategy.getCurrTask());   // TODO : Add log Info feature
             isDoneIterating = false;
             while (!isDoneIterating) {
-                // SearchStatistics.iteration++;   // TODO : Add log Info feature
+                 searchStrategy.incrementIteration();
+                // TODO : Add log Info feature
                 // PExplicitLogger.logStartIteration(searchStrategy.getCurrTask(), SearchStatistics.iteration, stepNumber); // TODO : Add log Info feature
                 if (stepNumber == 0) {
                     start();
@@ -448,7 +448,7 @@ public class ExplicitSearchScheduler extends Scheduler {
         }
     }
 
-    private void addRemainingChoicesAsChildrenTasks() {
+    private void addRemainingChoicesAsChildrenTasks() throws InterruptedException {
         SearchTask parentTask = searchStrategy.getCurrTask();
         int numChildrenAdded = 0;
         for (int i: parentTask.getSearchUnitKeys(false)) {
@@ -474,7 +474,7 @@ public class ExplicitSearchScheduler extends Scheduler {
         searchStrategy.getFinishedTasks().add(currTask.getId());
     }
 
-    private void setChildTask(SearchUnit unit, int choiceNum, SearchTask parentTask, boolean isExact) {
+    private void setChildTask(SearchUnit unit, int choiceNum, SearchTask parentTask, boolean isExact) throws InterruptedException {
         SearchTask newTask = SearchStrategy.createTask(parentTask);
 
         int maxChoiceNum = choiceNum;
@@ -503,7 +503,7 @@ public class ExplicitSearchScheduler extends Scheduler {
     /**
      * Set next backtrack task with given orchestration mode
      */
-    public SearchTask setNextTask() {
+    public SearchTask setNextTask() throws InterruptedException {
         SearchTask nextTask = searchStrategy.setNextTask();
         if (nextTask != null) {
             // PExplicitLogger.logNextTask(nextTask);    // TODO : Add log Info feature

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
@@ -1,16 +1,11 @@
 package pexplicit.runtime.scheduler.explicit.strategy;
 
 import lombok.Getter;
+import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.scheduler.explicit.SearchStatistics;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.Collections;
-
-import pexplicit.runtime.PExplicitGlobal;
+import java.util.*;
 
 @Getter
 public abstract class SearchStrategy implements Serializable {
@@ -22,12 +17,12 @@ public abstract class SearchStrategy implements Serializable {
      * Set of all search tasks that are pending
      */
     @Getter
-     final static  Set<Integer> pendingTasks = Collections.synchronizedSet(new HashSet<>()); // Is synchornized hash set
+    final static Set<Integer> pendingTasks = Collections.synchronizedSet(new HashSet<>()); // Is synchornized hash set
     /**
      * List of all search tasks that finished
      */
     @Getter
-     final static List<Integer> finishedTasks = Collections.synchronizedList(new ArrayList<>());
+    final static List<Integer> finishedTasks = Collections.synchronizedList(new ArrayList<>());
     /**
      * Task id of the latest search task
      */

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyAStar.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyAStar.java
@@ -4,25 +4,22 @@ import java.util.Comparator;
 import java.util.concurrent.PriorityBlockingQueue;
 
 public class SearchStrategyAStar extends SearchStrategy {
-    private final PriorityBlockingQueue<SearchTask> elements;
+    private static final PriorityBlockingQueue<SearchTask> elements =
+            new PriorityBlockingQueue<SearchTask>(
+                    100,
+                    new Comparator<SearchTask>() {
+                        public int compare(SearchTask a, SearchTask b) {
+                            return Integer.compare(a.getCurrChoiceNumber(), b.getCurrChoiceNumber());
+                        }
+                    });
 
-    public SearchStrategyAStar() {
-        elements =
-                new PriorityBlockingQueue<SearchTask>(
-                        100,
-                        new Comparator<SearchTask>() {
-                            public int compare(SearchTask a, SearchTask b) {
-                                return Integer.compare(a.getCurrChoiceNumber(), b.getCurrChoiceNumber());
-                            }
-                        });
-    }
+    public SearchStrategyAStar() {}
 
     public void addNewTask(SearchTask task) {
         elements.offer(task);
     }
 
     public SearchTask popNextTask() {
-        assert (!elements.isEmpty());
         return elements.poll();
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyAStar.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyAStar.java
@@ -13,7 +13,8 @@ public class SearchStrategyAStar extends SearchStrategy {
                         }
                     });
 
-    public SearchStrategyAStar() {}
+    public SearchStrategyAStar() {
+    }
 
     public void addNewTask(SearchTask task) {
         elements.offer(task);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyRandom.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyRandom.java
@@ -1,21 +1,17 @@
 package pexplicit.runtime.scheduler.explicit.strategy;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
-import java.util.concurrent.Semaphore;
-
 import pexplicit.utils.random.RandomNumberGenerator;
+
+import java.util.*;
+import java.util.concurrent.Semaphore;
 
 public class SearchStrategyRandom extends SearchStrategy {
     private static final Semaphore lock = new Semaphore(1);
     private static final List<SearchTask> elementList = new ArrayList<>();
     private static final Set<SearchTask> elementSet = new HashSet<>();
 
-    public SearchStrategyRandom() {}
+    public SearchStrategyRandom() {
+    }
 
     public void addNewTask(SearchTask task) throws InterruptedException {
         lock.acquire();

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyRandom.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyRandom.java
@@ -6,39 +6,42 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.Semaphore;
 
 import pexplicit.utils.random.RandomNumberGenerator;
 
 public class SearchStrategyRandom extends SearchStrategy {
-    private final List<SearchTask> elementList;
-    private final Set<SearchTask> elementSet;
+    private static final Semaphore lock = new Semaphore(1);
+    private static final List<SearchTask> elementList = new ArrayList<>();
+    private static final Set<SearchTask> elementSet = new HashSet<>();
 
-    public SearchStrategyRandom() {
-        elementList = new ArrayList<>();
-        elementSet = new HashSet<>();
-    }
+    public SearchStrategyRandom() {}
 
-    public void addNewTask(SearchTask task) {
+    public void addNewTask(SearchTask task) throws InterruptedException {
+        lock.acquire();
+
         assert (!elementSet.contains(task));
         elementList.add(task);
         elementSet.add(task);
+
+        lock.release();
     }
 
-    public SearchTask popNextTask() {
-        assert (!elementList.isEmpty());
+    public SearchTask popNextTask() throws InterruptedException {
+        lock.acquire();
+
+        if (elementList.isEmpty()) {
+            lock.release();
+            return null;
+        }
+
         Collections.shuffle(
                 elementList, new Random(RandomNumberGenerator.getInstance().getRandomLong()));
         SearchTask result = elementList.get(0);
         elementList.remove(0);
         elementSet.remove(result);
+
+        lock.release();
         return result;
     }
-
-    // public SearchTask popNextTaskAndCheckEmpty() {
-    //     if (isEmpty)
-    //         return false;
-    //     else popNextTask();
-    // }
-
-
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
@@ -2,7 +2,10 @@ package pexplicit.runtime.scheduler.explicit.strategy;
 
 import lombok.Getter;
 import pexplicit.runtime.machine.PMachineId;
-import pexplicit.runtime.scheduler.choice.*;
+import pexplicit.runtime.scheduler.choice.Choice;
+import pexplicit.runtime.scheduler.choice.DataSearchUnit;
+import pexplicit.runtime.scheduler.choice.ScheduleSearchUnit;
+import pexplicit.runtime.scheduler.choice.SearchUnit;
 import pexplicit.values.PValue;
 
 import java.io.Serializable;
@@ -16,11 +19,11 @@ public class SearchTask implements Serializable {
     @Getter
     private final List<SearchTask> children = new ArrayList<>();
     @Getter
-    private int currChoiceNumber = 0;
-    @Getter
     private final List<Choice> prefixChoices = new ArrayList<>();
     @Getter
     private final Map<Integer, SearchUnit> searchUnits = new HashMap<>();
+    @Getter
+    private int currChoiceNumber = 0;
 
     public SearchTask(int id, SearchTask parentTask) {
         this.id = id;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/TimedCall.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/TimedCall.java
@@ -1,18 +1,14 @@
 package pexplicit.utils.monitor;
 
+import lombok.Getter;
+import lombok.Setter;
 import pexplicit.runtime.PExplicitGlobal;
-import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.scheduler.Scheduler;
 import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.MemoutException;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
-
-import javax.annotation.concurrent.ThreadSafe;
-
-import lombok.Getter;
-import lombok.Setter;
 
 public class TimedCall implements Callable<Integer> {
     private final Scheduler scheduler;


### PR DESCRIPTION
Changes include:
- Make creation of first task to be done by one of the schedulers (to make sure correctly adding it to corresponding search strategy, not easy with a static call)
- Makes popNextTask and addNewTask thread safe for each SearchStrategy subclass
- Updates setNextTask to use popNextTask directly
- Minor compile time corrections
- Adds tracking number of schedules explored for current task in SearchStrategy
